### PR TITLE
Fix #28772: get_tick_params consistency for x and y axis

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1099,15 +1099,21 @@ class Axis(martist.Artist):
             'length': 'size',
             'direction': 'tickdir',
             'rotation': 'labelrotation',
-            'left': 'tick1On',
-            'bottom': 'tick1On',
-            'right': 'tick2On',
-            'top': 'tick2On',
-            'labelleft': 'label1On',
-            'labelbottom': 'label1On',
-            'labelright': 'label2On',
-            'labeltop': 'label2On',
         }
+        if self.axis_name == "x":
+            keymap.update({
+              'top': 'tick2On',
+              'bottom': 'tick1On',
+              'labelbottom': 'label1On',
+              'labeltop': 'label2On',
+            })
+        elif self.axis_name == "y":
+            keymap.update({
+              'left': 'tick1On',
+              'right': 'tick2On',
+              'labelleft': 'label1On',
+              'labelright': 'label2On',
+            })
         if reverse:
             kwtrans = {
                 oldkey: kw_.pop(newkey)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #28772, `axes.get_tick_params()` never returned labelbottom or labeltop. It does now with this fix.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

## Implementation notes

I can imagine that this fix should also include some compatibility with 3D plots (the z axis). However, I could not figure out how the two equivalents to 'top' and 'bottom', or 'left' and 'right' are called in the z axis in matplotlib ('front', 'back', maybe?).
